### PR TITLE
fix: export plain-date-month-types

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,5 +1,7 @@
 export * from "./plain-date.js";
 export * from "./plain-date-time.js";
+export * from "./plain-month-day.js";
 export * from "./plain-time.js";
+export * from "./plain-year-month.js";
 export * from "./root.js";
 export * from "./zoned-date-time.js";


### PR DESCRIPTION
Fixes #5.

Adds the two missing re-exports to src/providers/index.ts to make plan-month day and plain-year-month visible.

I'd be happy to update the demo to import all providers through src/index.js rather than via deep paths — that way a missing export would immediately cause a compile error and prevent this from recurring.